### PR TITLE
Add CONTRIBUTING.md to improve contributor onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,142 @@
+# Contributing to Proofolio
+
+Thank you for your interest in contributing to Proofolio.
+We welcome contributors of all skill levels and appreciate both code and non-code contributions.
+
+Please read this document carefully before starting.
+
+---
+
+## About the Project
+
+Proofolio is an AI-powered developer portfolio analyzer that transforms data from GitHub, LinkedIn, and blogs into a professional, recruiter-friendly performance report.
+
+---
+
+## Ways to Contribute
+
+You can contribute in the following areas:
+
+- Frontend (React + TypeScript)
+- Backend (Supabase)
+- UI/UX Design
+- Documentation & Community Support
+- Bug fixes, enhancements, and feature improvements
+
+Non-code contributions such as documentation improvements, typo fixes, and suggestions are also welcome.
+
+---
+
+## Getting Started
+
+### 1. Fork the Repository
+
+Click the **Fork** button on the top-right of the repository.
+
+### 2. Clone Your Fork
+
+```bash
+git clone https://github.com/<your-username>/proofolio.git
+cd proofolio
+```
+
+### 3. Install Dependencies
+
+```bash
+npm install
+```
+
+### 4. Create a New Branch
+
+```bash
+git checkout -b feature/your-feature-name
+```
+
+---
+
+## Issue Assignment Rules (SWoC Mandatory)
+
+This project strictly follows the SWoC Project Admin (PA) Playbook.
+
+- A contributor can be assigned only ONE issue at a time
+- Do NOT start working without being officially assigned
+- If no meaningful progress is shown for 10 days, the issue may be:
+- Unassigned
+- Reopened for other contributors
+
+Meaningful progress includes:
+- Commits pushed to your branch
+- Progress updates in the issue thread
+- Relevant discussions or clarifications
+
+---
+
+## Issue Difficulty & Scoring (SWoC)
+
+Each issue has exactly one SWoC difficulty tag:
+
+| Difficulty | Points |
+|------------|--------|
+| Easy       | 30     |
+| Medium     | 40     |
+| Hard       | 50     |
+
+Important notes:
+- Difficulty is decided only by the Project Admin
+- Points are awarded only after the PR is merged
+- Issues without proper SWoC tags are not eligible for scoring
+- Multiple difficulty tags on one issue are not allowed
+
+---
+
+## Pull Request Rules
+
+Do NOT open a PR without approval.
+
+Before opening a PR, you must:
+- Get officially assigned to the issue
+- Receive explicit permission to open a PR (if required)
+
+All PRs:
+- Are reviewed by Project Admins / Mentors
+- Must be original, meaningful, and follow project standards
+- Must resolve all review comments before merge
+
+Unauthorized PRs may be closed without review.
+
+---
+
+## Commit Guidelines
+
+Write clear and meaningful commit messages.
+
+Example:
+
+```bash
+git commit -m "Add CONTRIBUTING.md to improve contributor onboarding"
+```
+
+---
+
+## Code of Conduct & Fair Play
+
+All contributors are expected to:
+- Be respectful and professional
+- Avoid spam, plagiarism, or force-claiming issues
+- Follow ethical and fair contribution practices
+
+Violations may result in:
+- Issue unassignment
+- PR rejection
+- Reporting to the SWoC core team
+
+---
+
+## Need Help?
+
+If you’re unsure about anything:
+- Check existing issues
+- Ask questions in the issue thread
+- Reach out to the maintainers
+
+Happy contributing!


### PR DESCRIPTION
This PR adds a dedicated CONTRIBUTING.md file to the repository.

The new document clearly outlines:
- How to get started with the project
- Contribution areas (frontend, backend, UI/UX, docs)
- Branching and commit guidelines
- Issue assignment and PR rules (aligned with SWoC guidelines)
- Expected contributor conduct and fair play practices

Having a separate CONTRIBUTING.md improves contributor onboarding,
reduces confusion for first-time contributors, and keeps contribution
rules well-organized outside the README.

No existing code or functionality is modified.
